### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/io.gitlab.gregorni.Letterpress.json
+++ b/io.gitlab.gregorni.Letterpress.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.gitlab.gregorni.Letterpress",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "command" : "letterpress",
     "finish-args" : [


### PR DESCRIPTION
GNOME runtime version 46 will reach EOL on 2025-03-15.

Source: https://release.gnome.org/calendar/