### PR TITLE
runtime: update to 48 (with required blueprint update to 0.16.0)

### DIFF
--- a/io.gitlab.gregorni.Letterpress.json
+++ b/io.gitlab.gregorni.Letterpress.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.gitlab.gregorni.Letterpress",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "letterpress",
     "finish-args" : [
@@ -30,7 +30,7 @@
 	  	{
 	      	    "type": "git",
 	      	    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-	      	    "tag": "v0.12.0"
+	      	    "tag": "v0.16.0"
 	    	}
 	    ]
 	},


### PR DESCRIPTION
New runtime brings altered dark theme and corner radii of Libadwaita 1.7. Blueprint must be updated to build successfully.